### PR TITLE
update {get} UnturnedPlayer.Color 

### DIFF
--- a/Rocket.Unturned/Player/UnturnedPlayer.cs
+++ b/Rocket.Unturned/Player/UnturnedPlayer.cs
@@ -94,7 +94,7 @@ namespace Rocket.Unturned.Player
                 }
 
                 var groups = (List<RocketPermissionsGroup>)R.Permissions.GetGroups(unturnedPlayer, false).Where(g => g.Color != null && g.Color != "white");
-                RocketPermissionsGroup group;
+                RocketPermissionsGroup group = groups.FirstOrDefault();
                 if (U.Settings.Instance.EnableUnturnedPlayerColorFromPriorityGroup)
                 {
                     //group = groups.First(g => g.Priority == groups.Max(g => g.Priority));
@@ -107,10 +107,6 @@ namespace Rocket.Unturned.Player
                             group = item;
                         }
                     }
-                }
-                else
-                {
-                    group = groups.FirstOrDefault();
                 }
 
                 string color = "";

--- a/Rocket.Unturned/Player/UnturnedPlayer.cs
+++ b/Rocket.Unturned/Player/UnturnedPlayer.cs
@@ -93,7 +93,26 @@ namespace Rocket.Unturned.Player
                     return Palette.ADMIN;
                 }
 
-                RocketPermissionsGroup group = R.Permissions.GetGroups(this,false).Where(g => g.Color != null && g.Color != "white").FirstOrDefault();
+                var groups = (List<RocketPermissionsGroup>)R.Permissions.GetGroups(unturnedPlayer, false).Where(g => g.Color != null && g.Color != "white");
+                RocketPermissionsGroup group;
+                if (U.Settings.Instance.EnableUnturnedPlayerColorFromPriorityGroup)
+                {
+                    //group = groups.First(g => g.Priority == groups.Max(g => g.Priority));
+                    short priority = Int16.MaxValue;
+                    foreach (var item in groups)
+                    {
+                        if (item.Priority < priority)
+                        {
+                            priority = item.Priority;
+                            group = item;
+                        }
+                    }
+                }
+                else
+                {
+                    group = groups.FirstOrDefault();
+                }
+
                 string color = "";
                 if (group != null) color = group.Color;
                 return UnturnedChat.GetColorFromName(color, Palette.COLOR_W);

--- a/Rocket.Unturned/Player/UnturnedPlayer.cs
+++ b/Rocket.Unturned/Player/UnturnedPlayer.cs
@@ -93,12 +93,12 @@ namespace Rocket.Unturned.Player
                     return Palette.ADMIN;
                 }
 
-                var groups = (List<RocketPermissionsGroup>)R.Permissions.GetGroups(unturnedPlayer, false).Where(g => g.Color != null && g.Color != "white");
-                RocketPermissionsGroup group = groups.FirstOrDefault();
+                var groups = R.Permissions.GetGroups(this, false).Where(g => g.Color != null && g.Color != "white").ToList();
+                var group = groups.FirstOrDefault();
                 if (U.Settings.Instance.EnableUnturnedPlayerColorFromPriorityGroup)
                 {
                     //group = groups.First(g => g.Priority == groups.Max(g => g.Priority));
-                    short priority = Int16.MaxValue;
+                    var priority = short.MaxValue;
                     foreach (var item in groups)
                     {
                         if (item.Priority < priority)
@@ -108,7 +108,7 @@ namespace Rocket.Unturned.Player
                         }
                     }
                 }
-
+                
                 string color = "";
                 if (group != null) color = group.Color;
                 return UnturnedChat.GetColorFromName(color, Palette.COLOR_W);

--- a/Rocket.Unturned/Serialisation/UnturnedSettings.cs
+++ b/Rocket.Unturned/Serialisation/UnturnedSettings.cs
@@ -54,6 +54,8 @@ namespace Rocket.Unturned.Serialisation
 
         public bool EnableVehicleBlacklist;
 
+        public bool EnableUnturnedPlayerColorFromPriorityGroup;
+
 
         public void LoadDefaults()
         {
@@ -66,6 +68,7 @@ namespace Rocket.Unturned.Serialisation
             EnableItemSpawnLimit = false;
             MaxSpawnAmount = 10;
             EnableVehicleBlacklist = false;
+            EnableUnturnedPlayerColorFromPriorityGroup = false;
         }
     }
 }


### PR DESCRIPTION
I noticed that the priority is not used at all

add EnableUnturnedPlayerColorFromPriorityGroup (def is false) in config

select the desired option by the community - 2 cycles or with the priority value saved

// 

я заметил, что приоритет вообще нигде не используется

добавить EnableUnturnedPlayerColorFromPriorityGroup 
выбрать из двух вариантов - проход 2мя циклами или с сохранением значения