### PR TITLE
Fix invalid cast exception for /v command

### DIFF
--- a/Rocket.Unturned/Commands/CommandV.cs
+++ b/Rocket.Unturned/Commands/CommandV.cs
@@ -63,8 +63,9 @@ namespace Rocket.Unturned.Commands
                     throw new WrongUsageOfCommandException(caller, this);
                 }
 
-                Asset[] assets = Assets.find(EAssetType.VEHICLE);
-                foreach (VehicleAsset ia in assets.Cast<VehicleAsset>())
+                List<VehicleAsset> assets = new List<VehicleAsset>();
+                Assets.find(assets);
+                foreach (VehicleAsset ia in assets)
                 {
                     if (ia != null && ia.vehicleName != null && ia.vehicleName.ToLower().Contains(itemString.ToLower()))
                     {
@@ -80,6 +81,10 @@ namespace Rocket.Unturned.Commands
             }
 
             Asset a = Assets.find(EAssetType.VEHICLE, id.Value);
+            if (a is VehicleRedirectorAsset ra)
+            {
+                a = ra.TargetVehicle.Find();
+            }
             if (a == null)
             {
                 UnturnedChat.Say(caller, U.Translate("command_generic_invalid_parameter"));

--- a/Rocket.Unturned/Rocket.Unturned.csproj
+++ b/Rocket.Unturned/Rocket.Unturned.csproj
@@ -16,7 +16,7 @@
     <PackageReference Include="RocketModFix.UnityEngine.Redist" Version="2021.3.29.1">
       <PrivateAssets>All</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="RocketModFix.Unturned.Redist" Version="3.24.1">
+    <PackageReference Include="RocketModFix.Unturned.Redist.Server" Version="3.24.4">
       <PrivateAssets>All</PrivateAssets>
     </PackageReference>
   </ItemGroup>

--- a/Rocket/Rocket.API/Rocket.API.csproj
+++ b/Rocket/Rocket.API/Rocket.API.csproj
@@ -10,7 +10,7 @@
     <PackageReference Include="RocketModFix.UnityEngine.Redist" Version="2021.3.28.1">
       <PrivateAssets>All</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="RocketModFix.Unturned.Redist" Version="3.23.12.2">
+    <PackageReference Include="RocketModFix.Unturned.Redist.Server" Version="3.24.4">
       <PrivateAssets>All</PrivateAssets>
     </PackageReference>
   </ItemGroup>

--- a/Rocket/Rocket.Core/Rocket.Core.csproj
+++ b/Rocket/Rocket.Core/Rocket.Core.csproj
@@ -21,7 +21,7 @@
     <PackageReference Include="RocketModFix.UnityEngine.Redist" Version="2021.3.28.1">
       <PrivateAssets>All</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="RocketModFix.Unturned.Redist" Version="3.24.1">
+    <PackageReference Include="RocketModFix.Unturned.Redist.Server" Version="3.24.4">
       <PrivateAssets>All</PrivateAssets>
     </PackageReference>
   </ItemGroup>


### PR DESCRIPTION
`Assets.find(EAssetType.VEHICLE, id)` can now return `VehicleRedirectorAsset` introduced in 3.24.4.0 update